### PR TITLE
set content-type header in POST request

### DIFF
--- a/client.go
+++ b/client.go
@@ -81,10 +81,10 @@ func (c *ServiceClient) Head(servicePath string) (*http.Response, error) {
 // Post sends a POST request to the service.
 func (c *ServiceClient) Post(servicePath string, contentType string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodPost, servicePath, body)
-	req.Header.Set("Content-Type", contentType)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", contentType)
 	return c.Do(req)
 }
 

--- a/client.go
+++ b/client.go
@@ -54,7 +54,7 @@ func (c *ServiceClient) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	response := responseRecorder.Result()
-	clientRequestDebug.Tracef("Response from %s: status=%d, contentLength=%d", 
+	clientRequestDebug.Tracef("Response from %s: status=%d, contentLength=%d",
 		c.Name, response.StatusCode, response.ContentLength)
 
 	return response, nil
@@ -81,6 +81,7 @@ func (c *ServiceClient) Head(servicePath string) (*http.Response, error) {
 // Post sends a POST request to the service.
 func (c *ServiceClient) Post(servicePath string, contentType string, body io.Reader) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodPost, servicePath, body)
+	req.Header.Set("Content-Type", contentType)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
set content-type header in POST request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected formatting in debug log statements.
  - Ensured POST requests include the correct "Content-Type" header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->