### PR TITLE
ENG-1640 fixed data race in GatewayServiceIndexer

### DIFF
--- a/gateway-service-indexer.go
+++ b/gateway-service-indexer.go
@@ -1,10 +1,15 @@
 package zephyr
 
+import "sync"
+
 type GatewayServiceIndexer struct {
+	mu                 sync.Mutex
 	ServiceDescriptors []*ServiceDescriptor
 }
 
 func (r *GatewayServiceIndexer) SetServiceDescriptor(descriptor *ServiceDescriptor) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	for _, existingDescriptor := range r.ServiceDescriptors {
 		if existingDescriptor.Name == descriptor.Name {
 			existingDescriptor.RouteDescriptors = descriptor.RouteDescriptors
@@ -16,6 +21,8 @@ func (r *GatewayServiceIndexer) SetServiceDescriptor(descriptor *ServiceDescript
 }
 
 func (r *GatewayServiceIndexer) UnsetService(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	for i, service := range r.ServiceDescriptors {
 		if service.Name == name {
 			r.ServiceDescriptors = append(r.ServiceDescriptors[:i], r.ServiceDescriptors[i+1:]...)
@@ -26,6 +33,8 @@ func (r *GatewayServiceIndexer) UnsetService(name string) error {
 }
 
 func (r *GatewayServiceIndexer) ResolveService(method string, path string) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	for _, remoteService := range r.ServiceDescriptors {
 		if remoteService.UnreachableAt != nil {
 			continue


### PR DESCRIPTION
Fixed data race in GatewayServiceIndexer.

More info: https://linear.app/telemetrytv/issue/ENG-1640/fix-data-race-in-zephyr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when accessing service data in concurrent environments, preventing potential errors during simultaneous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->